### PR TITLE
Lower layer caches should preserve false-y values

### DIFF
--- a/src/Extensions/Chain.php
+++ b/src/Extensions/Chain.php
@@ -118,7 +118,9 @@ class Chain extends TaggableStore implements LockProvider
             return $cachedValue;
         }
 
-        if ($cachedValue = $this->cacheGet($key, $layer + 1)) {
+        $cachedValue = $this->cacheGet($key, $layer + 1);
+        
+        if ($cachedValue !== null) {
             if ($this->ttl > 0) {
                 $this->providers->get($layer)->put($key, $cachedValue, $this->ttl);
             } else {


### PR DESCRIPTION
If a higher-layer cache has a false-y value, such as an empty array or 0, the lower layer cache does not cache it and will always repeat going to the higher layer to retrieve that value.

Add a null-only check to the cacheGet method that stores the values in the lower layers