### PR TITLE
Chain cache configuration fix

### DIFF
--- a/src/AppServiceProvider.php
+++ b/src/AppServiceProvider.php
@@ -12,7 +12,7 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->app->booting(fn () => Cache::extend(
             'chain',
-            fn () => Cache::repository(new Chain())
+            fn ($app, $config) => Cache::repository(new Chain($config['providers'], $config['defaultTTL'] ?? 0))
         ));
     }
 }

--- a/src/Extensions/Chain.php
+++ b/src/Extensions/Chain.php
@@ -19,11 +19,11 @@ class Chain extends TaggableStore implements LockProvider
     private Collection $providers;
     private ?int $ttl;
 
-    public function __construct()
+    public function __construct(array $providers, ?int $ttl)
     {
-        $this->providers(Config::get('cache.stores.chain.providers'));
+        $this->providers($providers);
 
-        $this->ttl = Config::get('cache.stores.chain.defaultTTL');
+        $this->ttl = $ttl;
     }
 
     public function get($key)


### PR DESCRIPTION
Pass cache config through constructor rather than having it hardcoded.  Allows cache config to be named something other than ‘chain’ in addition to allowing multiple chain-based configurations.

With the config being passed through on cache initialization I can have multiple chain caches defined for my app:

```
'file-redis-chain' => [
    'driver' => 'chain',
    'providers' => [
        'file',
        'redis',
    ],
    'defaultTTL' => 600,
],

'array-s3-chain' => [
    'driver' => 'chain',
    'providers' => [
        'array',
        's3',
    ],
    'defaultTTL' => 0,
],
```